### PR TITLE
chore: rename repo without helm prefix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   version-bump:
     runs-on: ubuntu-latest
-    if: github.repository == 'taskmedia/helm_paperlessngx-ftp-bridge'
+    if: github.repository == 'taskmedia/paperlessngx-ftp-bridge'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
   build-image:
     needs: version-bump
     runs-on: ubuntu-latest
-    if: github.repository == 'taskmedia/helm_paperlessngx-ftp-bridge'
+    if: github.repository == 'taskmedia/paperlessngx-ftp-bridge'
     permissions:
       contents: read
       packages: write
@@ -143,7 +143,7 @@ jobs:
   helm-build-and-deploy:
     needs: build-image
     runs-on: ubuntu-latest
-    if: github.repository == 'taskmedia/helm_paperlessngx-ftp-bridge'
+    if: github.repository == 'taskmedia/paperlessngx-ftp-bridge'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ FROM scratch
 # see: https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
 LABEL org.opencontainers.image.title=paperless-ftp-bridge
 LABEL org.opencontainers.image.description="uploads files to a paperless-ng instance via FTP"
-LABEL org.opencontainers.image.url=https://github.com/taskmedia/helm_paperlessngx-ftp-bridge/pkgs/container/paperless-ftp-bridge
-LABEL org.opencontainers.image.source=https://github.com/taskmedia/helm_paperlessngx-ftp-bridge/blob/main/Dockerfile
+LABEL org.opencontainers.image.url=https://github.com/taskmedia/paperlessngx-ftp-bridge/pkgs/container/paperless-ftp-bridge
+LABEL org.opencontainers.image.source=https://github.com/taskmedia/paperlessngx-ftp-bridge/blob/main/Dockerfile
 LABEL org.opencontainers.image.vendor=task.media
 LABEL org.opencontainers.image.licenses=MIT
 

--- a/charts/paperlessngx-ftp-bridge/Chart.yaml
+++ b/charts/paperlessngx-ftp-bridge/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
   - name: fty4
     url: https://github.com/fty4
 sources:
-  - https://github.com/taskmedia/helm_paperlessngx-ftp-bridge
+  - https://github.com/taskmedia/paperlessngx-ftp-bridge
   - https://github.com/taskmedia/helm
 icon: https://media.task.media/images/logo.png
 type: application

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/taskmedia/helm_paperlessngx-ftp-bridge
+module github.com/taskmedia/paperlessngx-ftp-bridge
 
 go 1.23.1
 


### PR DESCRIPTION
No prefix is required - this is a standalone application. Helm is only a way (recommended) to deploy it.