### PR TITLE
fix: ensure pods are restarted on password update

### DIFF
--- a/charts/paperlessngx-ftp-bridge/templates/deployment.yaml
+++ b/charts/paperlessngx-ftp-bridge/templates/deployment.yaml
@@ -10,8 +10,9 @@ spec:
       {{- include "plngxftpbridge.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        secrets-hash: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
If passwords are updated a link (annotation) to the secrets file is required. otherwise the pod will not restart.