### PR TITLE
feat: allow to use existing secret for ftp / pl password

### DIFF
--- a/charts/paperlessngx-ftp-bridge/templates/deployment.yaml
+++ b/charts/paperlessngx-ftp-bridge/templates/deployment.yaml
@@ -37,8 +37,8 @@ spec:
             - name: FTP_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "plngxftpbridge.fullname" . }}
-                  key: ftp-password
+                  name: {{ default (include "plngxftpbridge.fullname" .) .Values.ftp.passwordExistingSecret.name }}
+                  key: {{ default "ftp-password" .Values.ftp.passwordExistingSecret.key }}
             - name: FTP_PATH
               value: "{{ .Values.ftp.path }}"
             - name: PAPERLESS_URL
@@ -48,8 +48,8 @@ spec:
             - name: PAPERLESS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "plngxftpbridge.fullname" . }}
-                  key: paperless-password
+                  name: {{ default (include "plngxftpbridge.fullname" .) .Values.paperless.passwordExistingSecret.name }}
+                  key: {{ default "paperless-password" .Values.paperless.passwordExistingSecret.key }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/paperlessngx-ftp-bridge/templates/secrets.yaml
+++ b/charts/paperlessngx-ftp-bridge/templates/secrets.yaml
@@ -1,8 +1,14 @@
+{{- if or .Values.ftp.password .Values.paperless.password }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ include "plngxftpbridge.fullname" . }}"
 type: Opaque
 stringData:
+  {{- if .Values.ftp.password }}
   ftp-password: {{ required "ftp.password is required" .Values.ftp.password | quote }}
+  {{- end }}
+  {{- if .Values.paperless.password }}
   paperless-password: {{ required "paperless.password is required" .Values.paperless.password | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/paperlessngx-ftp-bridge/values.yaml
+++ b/charts/paperlessngx-ftp-bridge/values.yaml
@@ -9,7 +9,12 @@ ftp:
   # e.g. ftp.example.org:21
   host: ""
   user: ""
+  # password for ftp connection
   password: ""
+  # passwordExistingSecret is used to reference an existing secret in the same namespace
+  passwordExistingSecret:
+    name: ""
+    key: ""
   path: "."
 
 # paperless-ngx configuration to send documents to
@@ -17,7 +22,12 @@ paperless:
   # url with protocol but no API endpoint
   url: "http://paperless-ngx:8000"
   username: ""
+  # password for paperless-ngx
   password: ""
+  # passwordExistingSecret is used to reference an existing secret in the same namespace
+  passwordExistingSecret:
+    name: ""
+    key: ""
 
 # image used for bridge
 image:


### PR DESCRIPTION
Allow to use existing secret for both ftp and paperless-ngx.